### PR TITLE
fix: APIFactory and DeliveryAPI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ builder := NewPromotedDeliveryClientBuilder()
 client, _ := builder.
   WithDeliveryEndpoint("<delivery endpoint from Promoted.ai>").
   WithDeliveryAPIKey("<delivery endpoint from Promoted.ai>").
-  WithMetricsEndpoint("<delivery endpoint from Promoted.ai>").
-  WithMetricsAPIKey("<delivery endpoint from Promoted.ai>").
+  WithMetricsEndpoint("<metrics endpoint from Promoted.ai>").
+  WithMetricsAPIKey("<metrics endpoint from Promoted.ai>").
   Build()
 ```
 

--- a/delivery/apifactory.go
+++ b/delivery/apifactory.go
@@ -4,7 +4,7 @@ package delivery
 type APIFactory interface {
 	CreateSDKDelivery() DeliveryAPI
 	CreateDeliveryAPI(endpoint, apiKey string, timeoutMillis int64, maxRequestInsertions int, acceptGzip, warmup bool) DeliveryAPI
-	CreateApiMetrics(endpoint, apiKey string, timeoutMillis int64) MetricsAPI
+	CreateMetricsAPI(endpoint, apiKey string, timeoutMillis int64) MetricsAPI
 }
 
 // DefaultAPIFactory is the default implementation of ApiFactory.

--- a/delivery/apifactory_test.go
+++ b/delivery/apifactory_test.go
@@ -1,0 +1,14 @@
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultAPIFactory_IsAPIFactory(t *testing.T) {
+	// Make sure this builds.
+	var apiFactory APIFactory
+	apiFactory = &DefaultAPIFactory{}
+	assert.NotNil(t, apiFactory)
+}

--- a/delivery/deliveryapi.go
+++ b/delivery/deliveryapi.go
@@ -91,7 +91,7 @@ func (d *PromotedDeliveryAPI) RunDelivery(deliveryRequest *DeliveryRequest) (*de
 	ctx, cancel := context.WithTimeout(context.Background(), d.timeoutDuration)
 	defer cancel()
 
-	requestBody, err := json.Marshal(deliveryRequest.Clone(d.maxRequestInsertions))
+	requestBody, err := json.Marshal(deliveryRequest.Clone(d.maxRequestInsertions).Request)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling delivery request: %v", err)
 	}

--- a/delivery/deliveryclientbuilder.go
+++ b/delivery/deliveryclientbuilder.go
@@ -127,7 +127,7 @@ func (b *PromotedDeliveryClientBuilder) Build() (*PromotedDeliveryClient, error)
 		b.warmup,
 	)
 
-	metricsAPI := b.apiFactory.CreateApiMetrics(
+	metricsAPI := b.apiFactory.CreateMetricsAPI(
 		b.metricsEndpoint,
 		b.metricsAPIKey,
 		b.metricsTimeoutMillis,

--- a/delivery/testutil_test.go
+++ b/delivery/testutil_test.go
@@ -23,7 +23,7 @@ func (f *TestApiFactory) CreateDeliveryAPI(endpoint, apiKey string, timeoutMilli
 }
 
 // CreateApiMetrics creates an API metrics instance.
-func (f *TestApiFactory) CreateApiMetrics(endpoint, apiKey string, timeoutMillis int64) MetricsAPI {
+func (f *TestApiFactory) CreateMetricsAPI(endpoint, apiKey string, timeoutMillis int64) MetricsAPI {
 	return f.metricsAPI
 }
 


### PR DESCRIPTION
3 fixes:
1. The APIFactory interface is broken.
2. PromotedDeliveryAPI sends `DeliveryRequest` to Delivery API instead of `DeliveryRequest.Request`.
3. This PR also fixes an issue in the README.

TESTING=none